### PR TITLE
ci: add GitHub action to package application as native executables

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
           reporter: java-junit
           fail-on-error: true
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: target/surefire-reports/

--- a/.github/workflows/create-executable.yml
+++ b/.github/workflows/create-executable.yml
@@ -1,0 +1,48 @@
+name: Create executables
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  package:
+    name: Create native packages
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Extract version from pom.xml
+        id: extract_version
+        run: |
+          version=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
+          echo "Extracted version: $version"
+          echo "version=$version" >> $GITHUB_ENV
+      - name: Build application
+        run: mvn -B package
+      - name: Package application with jpackage
+        run: |
+          mkdir -p dist
+          jpackage \
+            --type ${{ matrix.os == 'windows-latest' && 'exe' || (matrix.os == 'macos-latest' && 'pkg' || 'deb') }} \
+            --input target/ \
+            --main-jar pexi-${{ env.version }}.jar \
+            --name PEXI \
+            --app-version ${{ env.version }} \
+            --vendor "Henning Steinberg (drachenpapa)" \
+            --output dist/
+#            --icon src/main/resources/logo.${{ matrix.os == 'windows-latest' && 'ico' || (matrix.os == 'macos-latest' && 'icns' || 'png') }} \
+      - name: Upload packaged application
+        uses: actions/upload-artifact@v4
+        with:
+          name: PEXI-${{ matrix.os }}-package
+          path: dist/


### PR DESCRIPTION
## Pull Request Checklist
- [x] My code follows the code style of this project.
- [x] My commit message follows the [specified format](../CONTRIBUTING.md#commit-message-guidelines).
- [ ] My change requires a change to the documentation (e.g., README, code comments, API docs).
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] I have added unit/integration/UI tests to cover my changes (where applicable).
- [ ] I have updated the documentation accordingly.

---

## Related Issue
Issue Number: **#5**

---

## What is the current behavior?
Currently, PEXI is distributed as a JAR file, which requires users to have development expertise to execute it via the command line. This approach is not user-friendly and hinders adoption by non-technical users.

---

## What is the new behavior?
The new GitHub Action workflow automates the process of creating native executables:
- `.exe` for Windows users.
- `.pkg` for macOS users.
- `.deb` for Linux users.

Users can now download platform-specific executables directly from the GitHub actions artifacts, improving usability and accessibility.

---

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

---

## Does this deprecate any features?
- [ ] Yes
- [x] No

---

## Other Information
- The workflow currently skips setting an application icon (`--icon`) because appropriate formats (`.ico`, `.icns`, `.png`) are not yet available. This will be addressed in a future update.
